### PR TITLE
Ignore html comments

### DIFF
--- a/spec/processors/posthtmlSpec.js
+++ b/spec/processors/posthtmlSpec.js
@@ -72,6 +72,20 @@ describe('posthtml', () => {
       </div>
     `);
   });
+
+  it('ignores comment tags', () => {
+    expect(transform(`
+      <div prevent-widows>
+        <strong>Lorem ipsum dolar sit a-met</strong>
+        <!-- html comment -->
+      </div>
+    `)).toEqual(`
+      <div>
+        <strong>Lorem ipsum dolar sit a&#8209;met</strong>
+        <!-- html comment -->
+      </div>
+    `);
+  });
 });
 
 function transform(input, options) {

--- a/src/processors/posthtml.js
+++ b/src/processors/posthtml.js
@@ -13,6 +13,8 @@ module.exports = function(posthtmlOptions, textOptions) {
         return node;
       }
 
+      if (typeof node === 'string' && /<!--/g.test(node)) return node;
+
       return preventWidows(node);
     });
   }


### PR DESCRIPTION
Simple regex check for html comment during posthtml processing. Ignores html comments, as the replacement for hyphens breaks html comments