### PR TITLE
Allow posthtml to pass encoding options

### DIFF
--- a/spec/processors/posthtmlSpec.js
+++ b/spec/processors/posthtmlSpec.js
@@ -31,6 +31,20 @@ describe('posthtml', () => {
     `);
   });
 
+  it('allows encoding customization', () => {
+    expect(transform(`
+      <div prevent-widows>
+        <strong>Lorem ipsum</strong>
+        <strong>Lorem ipsum</strong>
+      </div>
+    `, { encoding: { space: '_' } })).toEqual(`
+      <div>
+        <strong>Lorem_ipsum</strong>
+        <strong>Lorem_ipsum</strong>
+      </div>
+    `);
+  });
+
   it('processes child nodes', () => {
     expect(transform(`
       <div prevent-widows>

--- a/src/processors/posthtml.js
+++ b/src/processors/posthtml.js
@@ -1,19 +1,19 @@
 const preventWidows = require('../index.js');
 
-module.exports = function(posthtmlOptions, textOptions) {
+module.exports = function(posthtmlOptions) {
   posthtmlOptions = posthtmlOptions || {};
 
   if ('attrName' in posthtmlOptions === false) posthtmlOptions.attrName = 'prevent-widows';
   if ('attrRemove' in posthtmlOptions === false) posthtmlOptions.attrRemove = true;
 
-  function processNodes(nodes) {
+  function processNodes(nodes, options) {
     return nodes.map(node => {
       if (typeof node == 'object') {
-        if (node.content) node.content = processNodes(node.content);
+        if (node.content) node.content = processNodes(node.content, options);
         return node;
       }
 
-      return preventWidows(node);
+      return preventWidows(node, options);
     });
   }
 
@@ -29,7 +29,7 @@ module.exports = function(posthtmlOptions, textOptions) {
       }
 
       // Apply the content
-      node.content = processNodes(node.content, textOptions);
+      node.content = processNodes(node.content, posthtmlOptions);
 
       return node;
     });


### PR DESCRIPTION
Pass posthtmlOptions through the function calls so that encoding options can be provided to the prevent widows processor